### PR TITLE
expose req object to the context

### DIFF
--- a/HttpServer.js
+++ b/HttpServer.js
@@ -17,6 +17,7 @@ function _fixRoute (route, project) {
     buildRoute({
       project: project,
       route: route,
+      req: rest.req,
       out: rest.res,
       params: rest.params,
       query: rest.url.query,


### PR DESCRIPTION
allows to interact with the request object directly in the handler. Would probably create `res` alias for `out` as well to make it consistent.