### PR TITLE
Add ability to handle unhandled routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,11 @@ exports.install = (pluginContext) => {
     sslKey: {
       type: String,
       description: 'Path to private SSL key (optional)'
+    },
+
+    routeNotFound: {
+      type: Function,
+      description: 'Function to handle missing routes (optional)'
     }
   });
 };

--- a/initializeRestHandler.js
+++ b/initializeRestHandler.js
@@ -7,6 +7,7 @@ module.exports = (httpServer) => {
   const logger = httpServer.logger;
   const requestLogger = httpServer.requestLogger;
   const colorsEnabled = project.getColors();
+  const routeNotFound = project.getRouteNotFound();
 
   httpServer.restHandler
     .on('route', (event) => {
@@ -39,6 +40,10 @@ module.exports = (httpServer) => {
     })
 
     .on('routeNotFound', (req, res) => {
-      requestLogger.info('NOT FOUND: ' + req.method + ' ' + req.url);
+      if (routeNotFound) {
+        routeNotFound(req, res);
+      } else {
+        requestLogger.info('NOT FOUND: ' + req.method + ' ' + req.url);
+      }
     });
 };


### PR DESCRIPTION
This allows you to manually handle unhandled requests in marko-starter.

like: 

```js
module.exports = require('marko-starter').projectConfig({
  routeNotFound(req, res) {
    res.end("wow");
  }
});
```

@austinkelleher @mlrawlings, thoughts?